### PR TITLE
Makes Pretrained consistent

### DIFF
--- a/quickvision/models/detection/detr/model_factory.py
+++ b/quickvision/models/detection/detr/model_factory.py
@@ -29,7 +29,7 @@ class vision_detr(nn.Module):
         return self.model(images)
 
 
-def create_vision_detr(num_classes, num_queries, backbone):
+def create_vision_detr(num_classes: int, num_queries: int, backbone):
     """
     Creates Detr Model for Object Detection
     Args:

--- a/quickvision/models/detection/faster_rcnn/lightning_trainer.py
+++ b/quickvision/models/detection/faster_rcnn/lightning_trainer.py
@@ -15,15 +15,15 @@ class lit_frcnn(pl.LightningModule):
     """
 
     def __init__(self, learning_rate: float = 0.0001, num_classes: int = 91,
-                 pretrained: bool = False, backbone: str = None, fpn: bool = True,
-                 pretrained_backbone: bool = True, trainable_backbone_layers: int = 3,
+                 backbone: str = None, fpn: bool = True,
+                 pretrained_backbone: str = None, trainable_backbone_layers: int = 3,
                  **kwargs, ):
         """
         Args:
             learning_rate: the learning rate
             num_classes: number of detection classes (including background)
             pretrained: if true, returns a model pre-trained on COCO train2017
-            pretrained_backbone: if true, returns a model with backbone pre-trained on Imagenet
+            pretrained_backbone (str): if "imagenet", returns a model with backbone pre-trained on Imagenet
             trainable_backbone_layers: number of trainable resnet layers starting from final block
         """
         super().__init__()
@@ -31,8 +31,7 @@ class lit_frcnn(pl.LightningModule):
         self.num_classes = num_classes
         self.backbone = backbone
         if backbone is None:
-            self.model = fasterrcnn_resnet50_fpn(pretrained=pretrained,
-                                                 pretrained_backbone=pretrained_backbone,
+            self.model = fasterrcnn_resnet50_fpn(pretrained=True,
                                                  trainable_backbone_layers=trainable_backbone_layers,)
 
             in_features = self.model.roi_heads.box_predictor.cls_score.in_features

--- a/quickvision/models/detection/retinanet/lightning_trainer.py
+++ b/quickvision/models/detection/retinanet/lightning_trainer.py
@@ -15,15 +15,15 @@ class lit_retinanet(pl.LightningModule):
     """
 
     def __init__(self, learning_rate: float = 0.0001, num_classes: int = 91,
-                 pretrained: bool = False, backbone: str = None, fpn: bool = True,
-                 pretrained_backbone: bool = True, trainable_backbone_layers: int = 3,
-                 replace_head: bool = True, **kwargs, ):
+                 backbone: str = None, fpn: bool = True,
+                 pretrained_backbone: str = None, trainable_backbone_layers: int = 3,
+                 **kwargs, ):
         """
         Args:
             learning_rate: the learning rate
             num_classes: number of detection classes (including background)
             pretrained: if true, returns a model pre-trained on COCO train2017
-            pretrained_backbone: if true, returns a model with backbone pre-trained on Imagenet
+            pretrained_backbone (str): if "imagenet", returns a model with backbone pre-trained on Imagenet
             trainable_backbone_layers: number of trainable resnet layers starting from final block
         """
         super().__init__()
@@ -31,8 +31,7 @@ class lit_retinanet(pl.LightningModule):
         self.num_classes = num_classes
         self.backbone = backbone
         if backbone is None:
-            self.model = retinanet_resnet50_fpn(pretrained=pretrained,
-                                                pretrained_backbone=pretrained_backbone, **kwargs)
+            self.model = retinanet_resnet50_fpn(pretrained=True, **kwargs)
 
             self.model.head = RetinaNetHead(in_channels=self.model.backbone.out_channels,
                                             num_anchors=self.model.head.classification_head.num_anchors,

--- a/tests/test_frcnn.py
+++ b/tests/test_frcnn.py
@@ -206,7 +206,7 @@ class LightningTester(unittest.TestCase):
         self.assertTrue(flag)
 
     def test_lit_forward(self):
-        model = faster_rcnn.lit_frcnn(num_classes=3, pretrained=None, pretrained_backbone=False)
+        model = faster_rcnn.lit_frcnn(num_classes=3, pretrained_backbone=False)
         image = torch.rand(1, 3, 400, 400)
         out = model(image)
         self.assertIsInstance(out, list)

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -189,7 +189,7 @@ class LightningTester(unittest.TestCase):
         self.assertTrue(flag)
 
     def test_lit_forward(self):
-        model = retinanet.lit_retinanet(num_classes=3, pretrained=None, pretrained_backbone=False)
+        model = retinanet.lit_retinanet(num_classes=3, pretrained_backbone=False)
         image = torch.rand(1, 3, 400, 400)
         out = model(image)
         self.assertIsInstance(out, list)


### PR DESCRIPTION
Suppresses #33

This does a small refactor for lightning trainers to support pretrained models.

Somehow this issue is not fully resolved. But this at least makes `pretrained` consistent to `str`.

We should try to avoid boolean for it.

A complete solution is rather hard. Plus lack of pretrained weights would simply keep creating errors here and there.

If community can contribute `resnet_fpn` weights. It would be great !! We can then think of adding that feature by changing a bit to the backbone API.

