### PR TITLE
Correcting incorrect types

### DIFF
--- a/quickvision/utils/nested_tensor_utils.py
+++ b/quickvision/utils/nested_tensor_utils.py
@@ -16,7 +16,7 @@ class NestedTensor(object):
         self.mask = mask
 
     def to(self, device):
-        # type: (Device) -> NestedTensor # noqa
+        # type: (torch.device) -> NestedTensor
         cast_tensor = self.tensors.to(device)
         mask = self.mask
         if mask is not None:


### PR DESCRIPTION
Hi @oke-aditya , Due to torchscript support `torch.device` now, I updated the `Device` to `torch.device`.