### PR TITLE
Fix model name in torch.hub

### DIFF
--- a/quickvision/models/detection/detr/model_factory.py
+++ b/quickvision/models/detection/detr/model_factory.py
@@ -60,7 +60,7 @@ def create_detr_backbone(model_name: str, pretrained: str = None,):
         backbone = torch.hub.load('facebookresearch/detr', 'detr_resnet50_dc5', pretrained=False)
 
     elif(model_name == "resnet101_dc5"):
-        backbone = torch.hub.load('facebookresearch/detr', 'detr_resnet50_dc5', pretrained=False)
+        backbone = torch.hub.load('facebookresearch/detr', 'detr_resnet101_dc5', pretrained=False)
 
     else:
         raise ValueError("Unuspported backbone")


### PR DESCRIPTION
Hi, the model `resnet101_dc5` is loaded into `detr_resnet50_dc5` now, I fixed it to `detr_resnet101_dc5` in this PR.